### PR TITLE
Update package.json by adding gatsby-plugin keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/Creatiwity/gatsby-plugin-core-js#readme",
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
     "polyfill",
     "core-js"
   ],


### PR DESCRIPTION
## Changes
* Added `gatsby-plugin` keyword to package.json
## Description
Hello. I found that the `package.json` file does not contain the keyword `gatsby-plugin`. This change will [submit the plugin to the Gatsby Plugin Library](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/). You can also go to gatsbyjs/gatsby#14013 for more detailed information. Thanks.